### PR TITLE
feat: Add RoundCompleted event for round lifecycle tracking

### DIFF
--- a/.ai/prd.md
+++ b/.ai/prd.md
@@ -178,8 +178,8 @@ The Lottery Operator is the person or entity responsible for deploying, configur
   - Given a draw is requested, when pickWinner() is called successfully, then a DrawRequested event is emitted
   - Given a winner is selected, when the draw completes, then a WinnerSelected event is emitted with indexed winnerAddress and prizeAmount
   - Given a prize transfer fails, when the winner cannot receive funds, then a PrizeTransferFailed event is emitted with indexed winnerAddress and prizeAmount
-  - Given any round completes, when it resets, then a RoundReset event is emitted with the new round number and timestamp
-  - Given I filter events, when I query by indexed parameters, then I can efficiently search by player address or winner
+  - Given any round completes (with or without winner), when it finishes, then a RoundCompleted event is emitted with indexed roundNumber, indexed winner address (or address(0) if no participants), and prize amount
+  - Given I filter events, when I query by indexed parameters, then I can efficiently search by player address, winner, or round number
   - Given I check event history, when I query the blockchain, then all lottery activities are permanently logged and auditable
 
 - **US-010: Secure Winner Withdrawal Pattern**

--- a/test/helpers/LogHelpers.sol
+++ b/test/helpers/LogHelpers.sol
@@ -5,7 +5,8 @@ import {Vm} from "forge-std/Vm.sol";
 
 library LogHelpers {
     function getWinner(Vm.Log[] memory logs) internal pure returns (address) {
-        return address(uint160(uint256(logs[0].topics[1])));
+        // RoundCompleted is now emitted before WinnerSelected, so winner is in logs[1]
+        return address(uint160(uint256(logs[1].topics[1])));
     }
 
     function getVrfRequestId(Vm.Log[] memory logs) internal pure returns (uint256) {


### PR DESCRIPTION
## Summary

Implements **US-009 AC5** to provide comprehensive observability for lottery round completions. Adds the `RoundCompleted` event that tracks when rounds finish, whether they end with a winner or without participants.

This PR evolved from the original issue #4 ("Add event for round reset") after discovering that `RoundCompleted` better captures the business semantics than `RoundReset`.

## Changes

### Contract (`src/Raffle.sol`)
- ✅ Add `RoundCompleted(uint256 indexed roundNumber, address indexed winner, uint256 prize)` event
- ✅ Add `s_roundNumber` state variable (initialized to 1, increments after each round)
- ✅ Add `NO_WINNER = address(0)` and `NO_PRIZE = 0` constants for code clarity
- ✅ Emit `RoundCompleted` after winner selection in `fulfillRandomWords()`
- ✅ Emit `RoundCompleted(s_roundNumber, NO_WINNER, NO_PRIZE)` when no participants
- ✅ Increment `s_roundNumber++` in `_resetRaffleForNextRound()`

### Tests (`test/unit/RaffleTest.t.sol`)
- ✅ Add `test_RoundCompletedEventEmittedAfterWinnerSelection()`
- ✅ Add `test_RoundCompletedEventEmittedWhenNoParticipants()`
- ✅ Update `LogHelpers` to handle new event order (RoundCompleted emitted before WinnerSelected)

### Documentation
- ✅ Update `.ai/prd.md` US-009 acceptance criteria with RoundCompleted event

## Design Decisions

### Named Constants for Clarity
Following Solidity community conventions (OpenZeppelin, Uniswap), we use named constants to make the code self-documenting:
```solidity
address private constant NO_WINNER = address(0);
uint256 private constant NO_PRIZE = 0;

emit RoundCompleted(s_roundNumber, NO_WINNER, NO_PRIZE); // Clear intent
```

### Event Semantics: RoundCompleted vs RoundReset
- `RoundCompleted` better expresses business intent ("round finished")
- Unified event for both completion scenarios (with/without winner)
- More intuitive than "reset" which implies returning to initial state

### Backward Compatibility
- Existing `WinnerSelected` event is preserved
- Both `RoundCompleted` and `WinnerSelected` are emitted (in that order)
- LogHelpers updated to reflect new event order

## Test Results

```
Ran 2 test suites: 27 tests passed, 0 failed, 0 skipped
  - 26 unit tests (including 2 new RoundCompleted tests)
  - 1 integration test
```

## Follow-up Work

Created issue #14 for future enhancement: Add `roundId` to all events (RaffleEntered, DrawRequested, WinnerSelected, PrizeTransferFailed) for better event correlation.

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RoundCompleted event that logs round number, winner address, and prize amount upon completion.
  * Enhanced event filtering to support queries by winner and round number.

* **Updates**
  * Changed prize withdrawal mechanism to a pull-payment pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->