### PR TITLE
fix: Enforce exact entry fee payment (#5)

### DIFF
--- a/src/Raffle.sol
+++ b/src/Raffle.sol
@@ -74,7 +74,7 @@ contract Raffle is VRFConsumerBaseV2Plus {
     }
 
     function enterRaffle() external payable {
-        if (msg.value < i_entranceFee) {
+        if (msg.value != i_entranceFee) {
             revert Raffle__SendMoreToEnterRaffle();
         }
 

--- a/test/unit/RaffleTest.t.sol
+++ b/test/unit/RaffleTest.t.sol
@@ -69,18 +69,6 @@ contract RaffleTest is Test {
         );
     }
 
-    function test_RaffleRevertsWhenYouDontPayEnough() public {
-        uint256 entranceFee = 0.01 ether;
-        uint256 insufficientPayment = entranceFee / 10;
-        Raffle raffle = _createRaffleWithEntranceFee(entranceFee);
-        address player = makeAddr("player");
-
-        _fundPlayerForRaffle(player, 1 ether);
-
-        vm.expectRevert(Raffle.Raffle__SendMoreToEnterRaffle.selector);
-        _enterRaffleAsPlayer(raffle, player, insufficientPayment);
-    }
-
     function test_RaffleRevertsWhenEnteringDuringDrawTime() public {
         uint256 entranceFee = 0.01 ether;
         uint256 interval = 30;
@@ -101,6 +89,18 @@ contract RaffleTest is Test {
         _enterRaffleAsPlayer(raffle, player2, entranceFee);
     }
 
+    function test_RaffleRevertsWhenYouDontPayEnough() public {
+        uint256 entranceFee = 0.01 ether;
+        uint256 insufficientPayment = entranceFee / 10;
+        Raffle raffle = _createRaffleWithEntranceFee(entranceFee);
+        address player = makeAddr("player");
+
+        _fundPlayerForRaffle(player, 1 ether);
+
+        vm.expectRevert(Raffle.Raffle__SendMoreToEnterRaffle.selector);
+        _enterRaffleAsPlayer(raffle, player, insufficientPayment);
+    }
+
     function test_RaffleAllowsUserToEnterWithEnoughFee() public {
         uint256 entranceFee = 0.01 ether;
         Raffle raffle = _createRaffleWithEntranceFee(entranceFee);
@@ -111,7 +111,7 @@ contract RaffleTest is Test {
         _enterRaffleAsPlayer(raffle, player, entranceFee);
     }
 
-    function test_RaffleAllowsUserToEnterWithMoreThanEnoughFee() public {
+    function test_RaffleRevertsWhenOverpaying() public {
         uint256 entranceFee = 0.01 ether;
         uint256 overpayment = entranceFee * 2;
         Raffle raffle = _createRaffleWithEntranceFee(entranceFee);
@@ -119,6 +119,7 @@ contract RaffleTest is Test {
 
         _fundPlayerForRaffle(player, 1 ether);
 
+        vm.expectRevert(Raffle.Raffle__SendMoreToEnterRaffle.selector);
         _enterRaffleAsPlayer(raffle, player, overpayment);
     }
 


### PR DESCRIPTION
## Summary

Fixes the raffle entry fee validation to enforce **exact** payment amounts, rejecting both underpayments and overpayments. This ensures fair participation and prevents users from accidentally overpaying.

## Changes

- **Raffle.sol (line 77)**: Changed validation from `msg.value < i_entranceFee` to `msg.value != i_entranceFee`
- **RaffleTest.t.sol**: Updated `test_RaffleAllowsUserToEnterWithMoreThanEnoughFee` to `test_RaffleRevertsWhenOverpaying` with proper revert expectation

## Test Results

✅ All 27 tests passing
- ✅ `test_RaffleRevertsWhenOverpaying` - Now correctly rejects overpayments
- ✅ `test_RaffleAllowsUserToEnterWithEnoughFee` - Still accepts exact payments
- ✅ `test_RaffleRevertsWhenYouDontPayEnough` - Still rejects underpayments

## User Story Compliance

Implements **US-002 AC2**: Given I send more than the entry fee, when I call enterRaffle(), then my transaction reverts with "Raffle__SendMoreToEnterRaffle"

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Raffle entry now requires an exact entrance fee payment. Previously accepted amounts greater than or equal to the entrance fee; now strictly enforces exact matching amounts. Overpayments will be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->