### PR TITLE
feat: Display entrance fee on raffle page (#44)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -7,3 +7,6 @@ VITE_WALLETCONNECT_PROJECT_ID=development
 # Get your API key at: https://www.alchemy.com/
 # Required for reliable balance fetching on Sepolia testnet
 VITE_ALCHEMY_API_KEY=your_alchemy_api_key_here
+
+# Raffle contract address
+VITE_RAFFLE_CONTRACT_ADDRESS=your_deployed_raffle_address

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { RainbowKitProvider } from '@rainbow-me/rainbowkit';
 import '@rainbow-me/rainbowkit/styles.css';
 import { config } from './config/wagmi';
 import { Header } from './components/Header';
+import { RaffleInfo } from './components/RaffleInfo';
 
 const queryClient = new QueryClient();
 
@@ -14,13 +15,9 @@ function App() {
         <RainbowKitProvider>
           <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
             <Header />
-            <div className="max-w-2xl mx-auto p-8">
-              <div className="bg-white rounded-2xl shadow-xl p-8 space-y-6">
-                <p className="text-gray-600 text-center">
-                  Connect your wallet to start playing the raffle
-                </p>
-              </div>
-            </div>
+            <main className="max-w-2xl mx-auto p-8">
+              <RaffleInfo />
+            </main>
           </div>
         </RainbowKitProvider>
       </QueryClientProvider>

--- a/frontend/src/components/RaffleInfo.tsx
+++ b/frontend/src/components/RaffleInfo.tsx
@@ -1,0 +1,24 @@
+import { useEntranceFee } from "@/hooks/useEntranceFee";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export function RaffleInfo() {
+  const { entranceFee, isLoading, error } = useEntranceFee();
+
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Raffle Information</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Entrance Fee</span>
+          <span className="font-semibold">
+            {isLoading && "Loading..."}
+            {error && "Error loading fee"}
+            {entranceFee && `${entranceFee} ETH`}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/config/contracts.ts
+++ b/frontend/src/config/contracts.ts
@@ -1,0 +1,14 @@
+import { type Address } from "viem";
+
+export const RAFFLE_ADDRESS = import.meta.env
+  .VITE_RAFFLE_CONTRACT_ADDRESS as Address;
+
+export const RAFFLE_ABI = [
+  {
+    type: "function",
+    name: "getEntranceFee",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+    stateMutability: "view",
+  },
+] as const;

--- a/frontend/src/hooks/useEntranceFee.ts
+++ b/frontend/src/hooks/useEntranceFee.ts
@@ -1,0 +1,17 @@
+import { useReadContract } from "wagmi";
+import { formatEther } from "viem";
+import { RAFFLE_ABI, RAFFLE_ADDRESS } from "@/config/contracts";
+
+export function useEntranceFee() {
+  const { data, isLoading, error } = useReadContract({
+    address: RAFFLE_ADDRESS,
+    abi: RAFFLE_ABI,
+    functionName: "getEntranceFee",
+  });
+
+  return {
+    entranceFee: data ? formatEther(data) : null,
+    isLoading,
+    error,
+  };
+}


### PR DESCRIPTION
## Summary
- Add RaffleInfo component displaying entrance fee from contract
- Create useEntranceFee hook using wagmi's useReadContract
- Add contract configuration with ABI and env-based address
- Update .env.example with VITE_RAFFLE_CONTRACT_ADDRESS

Closes #44

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] Verified entrance fee displays as 0.01 ETH on local Anvil
- [x] Confirmed with `cast call` that contract returns correct value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added raffle entrance fee display. The app now fetches and displays the current entrance fee from the smart contract in real-time.
  * Restructured the main interface to showcase raffle information and details prominently.
  * Implemented loading and error handling for improved user experience during data retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->