### PR TITLE
fix: Prevent flash of incorrect entry window state

### DIFF
--- a/frontend/src/hooks/useRaffleTimeRemaining.ts
+++ b/frontend/src/hooks/useRaffleTimeRemaining.ts
@@ -15,6 +15,8 @@ export function useRaffleTimeRemaining() {
     functionName: "getEntryDeadline",
   });
 
+  const [hasCalculated, setHasCalculated] = useState(false);
+
   const [timeLeft, setTimeLeft] = useState<TimeRemaining>({
     hours: 0,
     minutes: 0,
@@ -37,6 +39,7 @@ export function useRaffleTimeRemaining() {
           seconds: remainingSeconds % 60,
         });
       }
+      setHasCalculated(true);
     };
 
     // Calculate initial time immediately
@@ -50,11 +53,12 @@ export function useRaffleTimeRemaining() {
   const isEntryWindowClosed = useMemo(
     () =>
       !isLoading &&
+      hasCalculated &&
       deadline !== undefined &&
       timeLeft.hours === 0 &&
       timeLeft.minutes === 0 &&
       timeLeft.seconds === 0,
-    [isLoading, deadline, timeLeft]
+    [isLoading, hasCalculated, deadline, timeLeft]
   );
 
   return {


### PR DESCRIPTION
## Summary
Fixes race condition in `useRaffleTimeRemaining` hook that caused a brief visual flash of incorrect "Entry window closed" state.

## Problem
When the deadline was first loaded, there was one render cycle where:
- `deadline` was already fetched (`isLoading = false`)
- But `timeLeft` still had initial values `{0, 0, 0}`
- This caused `isEntryWindowClosed` to briefly return `true` incorrectly

This resulted in a visual flash where the UI showed "Entry window closed" for a split second before displaying the correct countdown timer.

## Solution
Added `hasCalculated` flag to track whether `updateTime()` has executed:
- Flag is set to `true` after first time calculation
- `isEntryWindowClosed` now checks `hasCalculated` before returning `true`
- This prevents the incorrect state from being shown before time is calculated

## Changes
- Added `hasCalculated` state flag
- Updated `updateTime()` to set `hasCalculated = true` after calculation
- Added `hasCalculated` to `isEntryWindowClosed` condition
- Added `hasCalculated` to useMemo dependencies

## Testing
- Manually tested and verified the flash no longer occurs
- TypeScript checks pass
- ESLint passes

## Related
- Addresses CodeRabbit feedback on PR #51
- Follow-up to #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of raffle countdown timer calculations by enhancing internal state management to ensure accurate timing updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->