### PR TITLE
feat: Live Players List with SSE updates (#68)

### DIFF
--- a/frontend/src/components/raffle/CurrentRoundCard.tsx
+++ b/frontend/src/components/raffle/CurrentRoundCard.tsx
@@ -1,14 +1,15 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { Ticket } from "lucide-react"
+import { Ticket, Users } from "lucide-react"
 
 interface CurrentRoundCardProps {
   entriesCount: number
   isLoadingEntries: boolean
   players: { address: string; entries: number }[]
+  connectedAddress?: string
 }
 
-export function CurrentRoundCard({ entriesCount, isLoadingEntries, players }: CurrentRoundCardProps) {
+export function CurrentRoundCard({ entriesCount, isLoadingEntries, players, connectedAddress }: CurrentRoundCardProps) {
   return (
     <Card className="border-4 border-cyan-400 bg-gradient-to-br from-purple-900/70 to-violet-900/70 backdrop-blur-sm shadow-[0_0_30px_rgba(34,211,238,0.4)] relative overflow-hidden">
       <div className="absolute inset-0 bg-gradient-to-br from-cyan-400/5 via-transparent to-purple-600/10"></div>
@@ -24,22 +25,46 @@ export function CurrentRoundCard({ entriesCount, isLoadingEntries, players }: Cu
         </div>
       </CardHeader>
       <CardContent className="relative z-10 max-h-96 overflow-y-auto">
-        <div className="space-y-2">
-          {players.map((player, i) => (
-            <div
-              key={i}
-              className="flex items-center justify-between rounded-lg bg-purple-950/50 border-2 border-cyan-600/30 p-3 hover:border-cyan-400/50 transition-colors"
-            >
-              <div className="flex items-center gap-2">
-                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-cyan-400 to-blue-500 text-xs font-black text-purple-950">
-                  #{i + 1}
+        {players.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <Users className="h-10 w-10 text-cyan-600/50 mb-3" />
+            <p className="text-cyan-400/60 font-bold text-sm">No players yet</p>
+            <p className="text-cyan-600/40 text-xs mt-1">Be the first to enter!</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {players.map((player, i) => {
+              const isConnectedUser = connectedAddress !== undefined && player.address === connectedAddress
+              return (
+                <div
+                  key={player.address}
+                  className={`flex items-center justify-between rounded-lg bg-purple-950/50 border-2 p-3 transition-colors ${
+                    isConnectedUser
+                      ? "border-amber-400/60 hover:border-amber-400/80"
+                      : "border-cyan-600/30 hover:border-cyan-400/50"
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <div className={`flex h-8 w-8 items-center justify-center rounded-full text-xs font-black text-purple-950 ${
+                      isConnectedUser
+                        ? "bg-gradient-to-br from-amber-300 to-yellow-500"
+                        : "bg-gradient-to-br from-cyan-400 to-blue-500"
+                    }`}>
+                      #{i + 1}
+                    </div>
+                    <span className={`font-mono text-sm font-bold ${
+                      isConnectedUser ? "text-amber-200" : "text-cyan-200"
+                    }`}>
+                      {player.address}
+                      {isConnectedUser && <span className="text-amber-400 ml-1">(you)</span>}
+                    </span>
+                  </div>
+                  <Badge className="bg-amber-400 text-purple-950 font-black">{player.entries}x</Badge>
                 </div>
-                <span className="font-mono text-sm font-bold text-cyan-200">{player.address}</span>
-              </div>
-              <Badge className="bg-amber-400 text-purple-950 font-black">{player.entries}x</Badge>
-            </div>
-          ))}
-        </div>
+              )
+            })}
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/frontend/src/config/contracts.ts
+++ b/frontend/src/config/contracts.ts
@@ -6,6 +6,13 @@ export const RAFFLE_ADDRESS = env.VITE_RAFFLE_CONTRACT_ADDRESS as Address;
 export const RAFFLE_ABI = [
   {
     type: "function",
+    name: "getRoundNumber",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "getEntranceFee",
     inputs: [],
     outputs: [{ name: "", type: "uint256", internalType: "uint256" }],

--- a/frontend/src/hooks/useCurrentRoundPlayers.ts
+++ b/frontend/src/hooks/useCurrentRoundPlayers.ts
@@ -1,0 +1,91 @@
+import { useState, useEffect, useCallback } from "react"
+import { INDEXER_URL } from "@/config/indexer"
+import { truncateAddress } from "@/lib/utils"
+import type { CurrentRoundPlayer } from "@/types/raffle"
+
+interface RoundPlayerData {
+  player: string
+  entryCount: number
+}
+
+interface GraphQLResponse {
+  data?: {
+    roundPlayers?: {
+      items: RoundPlayerData[]
+    }
+  }
+  errors?: { message: string }[]
+}
+
+const ROUND_PLAYERS_QUERY = `
+  query RoundPlayers($roundNumber: BigInt!) {
+    roundPlayers(where: { roundNumber: $roundNumber }, orderBy: "entryCount", orderDirection: "desc") {
+      items {
+        player
+        entryCount
+      }
+    }
+  }
+`
+
+interface UseCurrentRoundPlayersOptions {
+  roundNumber: bigint | undefined
+  enabled?: boolean
+}
+
+export function useCurrentRoundPlayers(options: UseCurrentRoundPlayersOptions) {
+  const { roundNumber, enabled = true } = options
+  const [players, setPlayers] = useState<CurrentRoundPlayer[]>([])
+  const [isLoading, setIsLoading] = useState(enabled && roundNumber !== undefined)
+  const [error, setError] = useState<Error | null>(null)
+
+  const fetchPlayers = useCallback(async () => {
+    if (roundNumber === undefined) return
+
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      const response = await fetch(`${INDEXER_URL}/graphql`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          query: ROUND_PLAYERS_QUERY,
+          variables: { roundNumber: roundNumber.toString() },
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error(`HTTP error: ${response.status}`)
+      }
+
+      const json: GraphQLResponse = await response.json()
+
+      if (json.errors) {
+        throw new Error(json.errors[0]?.message ?? "GraphQL error")
+      }
+
+      const items = json.data?.roundPlayers?.items ?? []
+
+      const transformed: CurrentRoundPlayer[] = items.map((item) => ({
+        address: truncateAddress(item.player),
+        entries: item.entryCount,
+      }))
+
+      setPlayers(transformed)
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error("Unknown error"))
+      setPlayers([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [roundNumber])
+
+  useEffect(() => {
+    if (enabled && roundNumber !== undefined) {
+      fetchPlayers()
+    }
+  }, [fetchPlayers, enabled, roundNumber])
+
+  return { players, isLoading, error }
+}

--- a/frontend/src/hooks/useLiveCurrentRoundPlayers.ts
+++ b/frontend/src/hooks/useLiveCurrentRoundPlayers.ts
@@ -1,0 +1,185 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { createClient } from "@ponder/client";
+import { desc, eq } from "drizzle-orm";
+import { MOCK_SSE, INDEXER_URL } from "@/config/indexer";
+import { truncateAddress } from "@/lib/utils";
+import { useCurrentRoundPlayers } from "@/hooks/useCurrentRoundPlayers";
+import { schema } from "@/lib/ponderSchema";
+import type { RoundPlayerFromPonder, CurrentRoundPlayer } from "@/types/raffle";
+
+const RECONNECT_DELAY = 2000;
+const MAX_RETRY_ATTEMPTS = 5;
+
+export interface UseLiveCurrentRoundPlayersOptions {
+  roundNumber: bigint | undefined;
+}
+
+export interface UseLiveCurrentRoundPlayersResult {
+  players: CurrentRoundPlayer[];
+  isLoading: boolean;
+}
+
+function isRoundPlayerFromPonder(obj: unknown): obj is RoundPlayerFromPonder {
+  if (typeof obj !== "object" || obj === null) return false;
+  const rec = obj as Record<string, unknown>;
+  return (
+    typeof rec.id === "string" &&
+    typeof rec.roundNumber === "bigint" &&
+    typeof rec.player === "string" &&
+    typeof rec.entryCount === "number"
+  );
+}
+
+function transformRoundPlayer(raw: RoundPlayerFromPonder): CurrentRoundPlayer {
+  return {
+    address: truncateAddress(raw.player),
+    entries: raw.entryCount,
+  };
+}
+
+export function useLiveCurrentRoundPlayers(
+  options: UseLiveCurrentRoundPlayersOptions
+): UseLiveCurrentRoundPlayersResult {
+  const { roundNumber } = options;
+
+  const graphqlResult = useCurrentRoundPlayers({
+    roundNumber,
+    enabled: !MOCK_SSE && roundNumber !== undefined,
+  });
+
+  const [players, setPlayers] = useState<CurrentRoundPlayer[]>([]);
+
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+  const unsubscribeRef = useRef<(() => void) | null>(null);
+  const isManualCloseRef = useRef(false);
+  const reconnectAttemptRef = useRef(0);
+  const startSSEConnectionRef = useRef<(() => Promise<void>) | null>(null);
+
+  useEffect(() => {
+    if (graphqlResult.players.length > 0 && players.length === 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setPlayers(graphqlResult.players);
+    }
+  }, [graphqlResult.players, players.length]);
+
+  // Clear players when round changes
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setPlayers([]);
+  }, [roundNumber]);
+
+  const startSSEConnection = useCallback(async () => {
+    if (MOCK_SSE) return;
+    if (isManualCloseRef.current) return;
+    if (roundNumber === undefined) return;
+
+    try {
+      const client = createClient(`${INDEXER_URL}/sql`, { schema });
+
+      const { unsubscribe } = await client.live(
+        (db) =>
+          db
+            .select()
+            .from(schema.roundPlayer)
+            .where(eq(schema.roundPlayer.roundNumber, roundNumber))
+            .orderBy(desc(schema.roundPlayer.entryCount)),
+
+        (result) => {
+          if (isManualCloseRef.current) return;
+
+          reconnectAttemptRef.current = 0;
+
+          const rows = Array.isArray(result) ? result : [];
+          const transformed = rows
+            .filter(isRoundPlayerFromPonder)
+            .map(transformRoundPlayer);
+
+          setPlayers(transformed);
+        },
+
+        (err) => {
+          if (isManualCloseRef.current) return;
+
+          const nextAttempt = reconnectAttemptRef.current + 1;
+          reconnectAttemptRef.current = nextAttempt;
+
+          console.error("SSE round players connection error:", err);
+
+          if (unsubscribeRef.current) {
+            try {
+              unsubscribeRef.current();
+              unsubscribeRef.current = null;
+            } catch {
+              // Ignore cleanup errors
+            }
+          }
+
+          if (nextAttempt > MAX_RETRY_ATTEMPTS) return;
+
+          if (reconnectTimeoutRef.current) {
+            clearTimeout(reconnectTimeoutRef.current);
+          }
+
+          reconnectTimeoutRef.current = setTimeout(() => {
+            startSSEConnectionRef.current?.();
+          }, RECONNECT_DELAY);
+        }
+      );
+
+      unsubscribeRef.current = unsubscribe;
+    } catch (err) {
+      if (isManualCloseRef.current) return;
+
+      const nextAttempt = reconnectAttemptRef.current + 1;
+      reconnectAttemptRef.current = nextAttempt;
+
+      console.error("SSE round players connection failed:", err);
+
+      if (nextAttempt > MAX_RETRY_ATTEMPTS) return;
+
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
+
+      if (!isManualCloseRef.current) {
+        reconnectTimeoutRef.current = setTimeout(() => {
+          startSSEConnectionRef.current?.();
+        }, RECONNECT_DELAY);
+      }
+    }
+  }, [roundNumber]);
+
+  useEffect(() => {
+    startSSEConnectionRef.current = startSSEConnection;
+  }, [startSSEConnection]);
+
+  useEffect(() => {
+    if (MOCK_SSE) return;
+    if (roundNumber === undefined) return;
+    if (graphqlResult.isLoading) return;
+
+    isManualCloseRef.current = false;
+    reconnectAttemptRef.current = 0;
+    startSSEConnection();
+
+    return () => {
+      isManualCloseRef.current = true;
+      if (unsubscribeRef.current) {
+        try {
+          unsubscribeRef.current();
+          unsubscribeRef.current = null;
+        } catch {
+          // Ignore
+        }
+      }
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
+    };
+  }, [startSSEConnection, graphqlResult.isLoading, roundNumber]);
+
+  return {
+    players,
+    isLoading: graphqlResult.isLoading,
+  };
+}

--- a/frontend/src/hooks/useRoundNumber.ts
+++ b/frontend/src/hooks/useRoundNumber.ts
@@ -1,0 +1,17 @@
+import { useReadContract } from "wagmi";
+import { RAFFLE_ABI, RAFFLE_ADDRESS } from "@/config/contracts";
+
+export function useRoundNumber() {
+  const { data, isLoading, error, refetch } = useReadContract({
+    address: RAFFLE_ADDRESS,
+    abi: RAFFLE_ABI,
+    functionName: "getRoundNumber",
+  });
+
+  return {
+    roundNumber: data as bigint | undefined,
+    isLoading,
+    error,
+    refetch,
+  };
+}

--- a/frontend/src/lib/ponderSchema.ts
+++ b/frontend/src/lib/ponderSchema.ts
@@ -6,7 +6,7 @@
  * If you modify the indexer schema, you MUST update this file!
  * Failure to sync will cause runtime errors without TypeScript warnings.
  *
- * Last synced: 2026-02-10
+ * Last synced: 2026-02-12
  */
 
 import { onchainTable } from "ponder";
@@ -19,4 +19,11 @@ export const round = onchainTable("round", (t) => ({
   completedAt: t.bigint().notNull(),
 }));
 
-export const schema = { round };
+export const roundPlayer = onchainTable("round_player", (t) => ({
+  id: t.text().primaryKey(),
+  roundNumber: t.bigint().notNull(),
+  player: t.hex().notNull(),
+  entryCount: t.integer().notNull(),
+}));
+
+export const schema = { round, roundPlayer };

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -23,28 +23,13 @@ import { useUnclaimedPrize } from "@/hooks/useUnclaimedPrize"
 import { usePlayerEntryCount } from "@/hooks/usePlayerEntryCount"
 import { useClaimPrize } from "@/hooks/useClaimPrize"
 import { useLiveRecentWinners } from "@/hooks/useLiveRecentWinners"
+import { useRoundNumber } from "@/hooks/useRoundNumber"
+import { useLiveCurrentRoundPlayers } from "@/hooks/useLiveCurrentRoundPlayers"
 import { useDismissableError } from "@/hooks/useDismissableError"
+import { truncateAddress } from "@/lib/utils"
 import type { DrawingResult } from "@/types/raffle"
 import { TARGET_CHAIN_ID } from "@/config/env"
 import { sepolia, anvil } from "wagmi/chains"
-
-const CURRENT_PLAYERS = [
-  { address: "0x742d...9f3a", entries: 5 },
-  { address: "0x8c3f...4e2b", entries: 3 },
-  { address: "0x1a5b...7c8d", entries: 2 },
-  { address: "0x9e2a...3b1f", entries: 1 },
-  { address: "0x5d1c...8a4e", entries: 1 },
-  { address: "0x4c8f...9e3a", entries: 4 },
-  { address: "0x7a2b...5d1c", entries: 2 },
-  { address: "0x3e9f...8c6b", entries: 3 },
-  { address: "0x6b1d...4f7a", entries: 1 },
-  { address: "0x9f4e...2c8d", entries: 2 },
-  { address: "0x2d7a...6e9b", entries: 1 },
-  { address: "0x8c3e...1f4d", entries: 3 },
-  { address: "0x5f9b...7a2e", entries: 1 },
-  { address: "0x1e6c...9d4f", entries: 2 },
-  { address: "0x4a8d...3c7e", entries: 1 },
-]
 
 export function RafflePage() {
   const { isConnected, address, chain } = useAccount()
@@ -57,6 +42,8 @@ export function RafflePage() {
   const { playerEntryCount, refetch: refetchPlayerEntryCount } = usePlayerEntryCount(address)
   const { claimPrize, isPending: isClaimPending, isSuccess: isClaimSuccess, isError: isClaimError, error: claimError } = useClaimPrize()
 
+  const { roundNumber, refetch: refetchRoundNumber } = useRoundNumber()
+  const { players: currentPlayers } = useLiveCurrentRoundPlayers({ roundNumber })
   const { winners: recentWinners, isLoading: isLoadingWinners } = useLiveRecentWinners({ limit: 12 })
   const [drawingResult, setDrawingResult] = useState<DrawingResult | null>(null)
 
@@ -101,6 +88,7 @@ export function RafflePage() {
       refetchUnclaimedPrize()
       refetchDeadline()
       refetchPlayerEntryCount()
+      refetchRoundNumber()
     },
   })
 
@@ -249,7 +237,8 @@ export function RafflePage() {
             <CurrentRoundCard
               entriesCount={entriesCount}
               isLoadingEntries={isLoadingEntries}
-              players={CURRENT_PLAYERS}
+              players={currentPlayers}
+              connectedAddress={address ? truncateAddress(address) : undefined}
             />
             <PlayerStatsCard
               playerEntryCount={playerEntryCount}

--- a/frontend/src/types/raffle.ts
+++ b/frontend/src/types/raffle.ts
@@ -19,3 +19,15 @@ export interface RecentWinner {
   prize: string
   time: string
 }
+
+export interface RoundPlayerFromPonder {
+  id: string
+  roundNumber: bigint
+  player: `0x${string}`
+  entryCount: number
+}
+
+export interface CurrentRoundPlayer {
+  address: string
+  entries: number
+}

--- a/indexer/ponder.config.ts
+++ b/indexer/ponder.config.ts
@@ -14,7 +14,7 @@ export default createConfig({
     Raffle: {
       chain: "anvil",
       abi: RaffleAbi,
-      address: "0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9",
+      address: process.env.RAFFLE_CONTRACT_ADDRESS as `0x${string}`,
       startBlock: 0,
     },
   },

--- a/indexer/ponder.schema.ts
+++ b/indexer/ponder.schema.ts
@@ -7,3 +7,10 @@ export const round = onchainTable("round", (t) => ({
   prizePool: t.bigint().notNull(),
   completedAt: t.bigint().notNull(),
 }));
+
+export const roundPlayer = onchainTable("round_player", (t) => ({
+  id: t.text().primaryKey(),
+  roundNumber: t.bigint().notNull(),
+  player: t.hex().notNull(),
+  entryCount: t.integer().notNull(),
+}));

--- a/indexer/src/index.ts
+++ b/indexer/src/index.ts
@@ -1,6 +1,20 @@
 import { ponder } from "ponder:registry";
-import { round } from "ponder:schema";
+import { round, roundPlayer } from "ponder:schema";
 import { zeroAddress } from "viem";
+
+ponder.on("Raffle:RaffleEntered", async ({ event, context }) => {
+  const { roundNumber, player } = event.args;
+
+  await context.db
+    .insert(roundPlayer)
+    .values({
+      id: `${roundNumber}-${player}`,
+      roundNumber,
+      player,
+      entryCount: 1,
+    })
+    .onConflictDoUpdate((row) => ({ entryCount: row.entryCount + 1 }));
+});
 
 ponder.on("Raffle:DrawCompleted", async ({ event, context }) => {
   const { roundNumber, winner, prize } = event.args;


### PR DESCRIPTION
## Summary
- Index `RaffleEntered` events into `round_player` table in Ponder indexer
- Add SSE-powered live current round players list on frontend
- Highlight connected user's entry with distinct amber styling and "(you)" label
- Show empty state when no players have entered the current round
- Move Raffle contract address to environment variable in indexer config

Closes #68

## Test plan
- [ ] Three wallets enter with different entry counts — list shows all with correct badges
- [ ] Addresses displayed in truncated format (0x742d...9f3a)
- [ ] New player enters while viewing — list updates without page refresh
- [ ] Existing player enters again — entry count badge increments live
- [ ] After draw completes, players list resets to empty
- [ ] Connected user's entry is visually highlighted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced player list in current round display with automatic highlighting for your wallet address
  * Added empty state indicator when raffle has no active participants
  * Live real-time updates to the participant list during active rounds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->