### PR TITLE
feat: visual separation between raffle rounds (#81)

### DIFF
--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -116,9 +116,6 @@ export function RafflePage() {
       } else {
         setPendingDrawResult(result)
       }
-      // Only update Prize Pool and Your Winnings immediately
-      // Everything else updates when user clicks "NEXT ROUND"
-      refetchPrizePool()
       refetchUnclaimedPrize()
     },
   })
@@ -232,6 +229,7 @@ export function RafflePage() {
               refetchEntries()
               refetchPlayerEntryCount()
               refetchRoundNumber()
+              refetchPrizePool()
             }}
           />
         )}

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -61,12 +61,19 @@ export function RafflePage() {
 
   const { roundNumber, refetch: refetchRoundNumber } = useRoundNumber()
   const { players: currentPlayers } = useLiveCurrentRoundPlayers({ roundNumber })
-  const { winners: recentWinners, isLoading: isLoadingWinners } = useLiveRecentWinners({ limit: 9 })
+  const { winners: liveRecentWinners, isLoading: isLoadingWinners } = useLiveRecentWinners({ limit: 9 })
   const [drawingResult, setDrawingResult] = useState<DrawingResult | null>(null)
   const [pendingDrawResult, setPendingDrawResult] = useState<DrawingResult | null>(null)
 
   const spinTarget = pendingDrawResult?.winner ?? null
   const frozen = pendingDrawResult !== null || drawingResult !== null
+
+  const [displayedWinners, setDisplayedWinners] = useState(liveRecentWinners)
+  useEffect(() => {
+    if (!frozen) {
+      setDisplayedWinners(liveRecentWinners)
+    }
+  }, [frozen, liveRecentWinners])
 
   const {
     errorMessage,
@@ -317,7 +324,7 @@ export function RafflePage() {
           </div>
         </div>
 
-        <RecentWinnersCard winners={recentWinners} isLoading={isLoadingWinners} />
+        <RecentWinnersCard winners={displayedWinners} isLoading={isLoadingWinners} />
       </div>
     </div>
   )

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -123,7 +123,6 @@ export function RafflePage() {
       } else {
         setPendingDrawResult(result)
       }
-      refetchUnclaimedPrize()
     },
   })
 
@@ -237,6 +236,7 @@ export function RafflePage() {
               refetchPlayerEntryCount()
               refetchRoundNumber()
               refetchPrizePool()
+              refetchUnclaimedPrize()
             }}
           />
         )}

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -71,6 +71,7 @@ export function RafflePage() {
   const [displayedWinners, setDisplayedWinners] = useState(liveRecentWinners)
   useEffect(() => {
     if (!frozen) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDisplayedWinners(liveRecentWinners)
     }
   }, [frozen, liveRecentWinners])


### PR DESCRIPTION
## Summary

- Add visual separation between raffle rounds with a result banner shown after each draw
- Keep UI frozen until user explicitly clicks NEXT ROUND, preventing any data from updating prematurely
- Fix prize pool resetting to 0 while wheel is still spinning
- Fix recent winners list revealing the winner before the wheel stops
- Fix "Your Winnings" section showing the prize before the wheel stops

## Changes

All three data leaks shared the same root cause: `DrawCompleted` fires after the contract has already distributed the prize, so any refetch at that moment returns the post-draw state. Fixes move all refetches to the NEXT ROUND handler, keeping the UI frozen at the pre-draw state during the wheel animation.

Recent winners list required a separate `displayedWinners` snapshot since the Ponder SSE subscription updates independently of the wheel state.

## Test plan

- [ ] Enter raffle and wait for draw — wheel starts spinning, prize pool stays at winning amount (not 0)
- [ ] While wheel is spinning — recent winners list does not show the new winner yet
- [ ] While wheel is spinning — "Your Winnings" does not reveal the prize yet
- [ ] After wheel stops — result banner appears with winner and prize amount
- [ ] After clicking NEXT ROUND — prize pool resets to 0, recent winners list and "Your Winnings" update

Closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Recent winners list now displays and updates only during active draws, remaining static between rounds.
  * Prize pool and unclaimed prize data refresh when advancing to the next round, optimizing the data update timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->